### PR TITLE
Remove unused nanoid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "glamor": "^2.20.40",
         "gravatar": "^1.8.1",
         "just-omit": "^1.0.1",
-        "nanoid": "^2.0.1",
         "next": "^16.1.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -5348,12 +5347,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "glamor": "^2.20.40",
     "gravatar": "^1.8.1",
     "just-omit": "^1.0.1",
-    "nanoid": "^2.0.1",
     "next": "^16.1.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -41,7 +40,7 @@
     "prettier": "^1.15.3",
     "prop-types": "^15.7.2"
   },
-"lint-staged": {
+  "lint-staged": {
     "{src,pages}/**/*.{js,jsx,css}": [
       "prettier --write",
       "git add"


### PR DESCRIPTION
## Summary
- Removed `nanoid` (^2.0.1) from direct dependencies -- it's not imported anywhere in the codebase

## Test plan
- [x] Verified no source files import nanoid
- [ ] Confirm site builds and deploys correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)